### PR TITLE
fix: handle types with generic arguments

### DIFF
--- a/src/Serilog.Enrichers.ShortTypeName/ShortTypeNameEnricher.cs
+++ b/src/Serilog.Enrichers.ShortTypeName/ShortTypeNameEnricher.cs
@@ -18,7 +18,8 @@ namespace Serilog.Enrichers.ShortTypeName
 
             if (logEvent.Properties.TryGetValue("SourceContext", out var value))
             {
-                var source = value.ToString().Replace("\"", string.Empty, StringComparison.Ordinal).Split('.').Last();
+                var typeNameWithoutGenerics = value.ToString().Replace("\"", string.Empty, StringComparison.Ordinal).Split('`').First();
+                var source = typeNameWithoutGenerics.Split('.').Last();
 
                 logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("ShortTypeName", source));
             }

--- a/test/Serilog.Enrichers.ShortTypeName.Tests/ShortTypeNameEnricherTests.cs
+++ b/test/Serilog.Enrichers.ShortTypeName.Tests/ShortTypeNameEnricherTests.cs
@@ -13,6 +13,8 @@ namespace Serilog.Enrichers.ShortTypeName.Tests
         [TestCase("Assembly.MyType")]
         [TestCase("Assembly.Very.Long.Namespace.MyType")]
         [TestCase("MyType")]
+        [TestCase("Controls.Device.Domain.Transport.MyType`1[[Controls.Device.Domain.Boxes.Box, Controls.Device.Domain, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]")]
+        [TestCase("Assembly.MyType`3[[System.Int32, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Net.IPAddress, System.Net.Primitives, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a],[System.Exception, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]")]
         public void Enrich_ShouldShortenName(string longName)
         {
             // Arrange


### PR DESCRIPTION
This avoids situations when type name is incorrectly reported as e.g. 
`0, Culture=neutral, PublicKeyToken=null`
in logs